### PR TITLE
Removed AbstractSyncableCollectionResponseSummaryV5 from AbstractSyncableDTO type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A library of DTO interfaces for integrating with the Diamond Kinetics public API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/dto/abstract-syncable.dto.ts
+++ b/src/lib/dto/abstract-syncable.dto.ts
@@ -4,4 +4,4 @@ import { AbstractSyncableDTOV4 } from './v4';
 import { AbstractSyncableCollectionResponseSummaryV5, AbstractSyncableResponseV5 } from "./v5/abstract-syncable.dto.v5";
 
 export type AbstractSyncableDTO = AbstractSyncableDTOV2 | AbstractActivityDTOV3 | AbstractSyncableDTOV4
-    | AbstractSyncableResponseV5 | AbstractSyncableCollectionResponseSummaryV5;
+    | AbstractSyncableResponseV5;


### PR DESCRIPTION
Its collected nature does not follow the spirit of the type since the type is for singular DTOs and is missing a uuid field