### PR TITLE
Update criteria types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondkinetics/dk-public-dto-ts",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/faker": "^4.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A library of DTO interfaces for integrating with the Diamond Kinetics public API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/types/criteria-type.ts
+++ b/src/lib/types/criteria-type.ts
@@ -1,6 +1,8 @@
 export const CriteriaTypes = [
   'HOME_RUNS',
   'SWINGS',
+  'SENSORLESS_SWINGS',
+  'SENSOR_SWINGS',
   'GAMES_PLAYED',
   'GUIDED_SESSIONS',
   'OPEN_SESSIONS',
@@ -12,5 +14,7 @@ export const CriteriaTypes = [
   'PERSONAL_BEST',
   'THROWS',
   'LEVEL_STATUS',
+  'EXPERIENCE_GAINED',
+  'SWING_MINUTES',
 ] as const;
 export type CriteriaType = (typeof CriteriaTypes)[number];


### PR DESCRIPTION
This updates our type for the CriteriaType enum, which now matches what we have in the API.

Once this is published, the web app can be updated to correctly use the `EXPERIENCE_GAINED` criteria type.