### PR TITLE
Add connection property to leaderboard entry response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondkinetics/dk-public-dto-ts",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/faker": "^4.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A library of DTO interfaces for integrating with the Diamond Kinetics public API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/dto/v6/response/leaderboard-entry-response-v6.ts
+++ b/src/lib/dto/v6/response/leaderboard-entry-response-v6.ts
@@ -5,4 +5,5 @@ export interface LeaderboardEntryResponseV6 {
   value: number;
   levelStatusName: string;
   specifiedUser: boolean;
+  connection: boolean;
 }


### PR DESCRIPTION
# What's Here

To support filtering down challenge leaderboard entries to a user's friends, this connection property needs to be added since it is now a part of the response from the API.

## Related Issues

[dk-product#1770](https://app.zenhub.com/workspaces/wksp-product-development-6005e69aabaf26000ee9caa3/issues/gh/diamondkinetics/dk-product/1770)