### PR TITLE
Remove export of mocks that no longer exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondkinetics/dk-public-dto-ts",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondkinetics/dk-public-dto-ts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A library of DTO interfaces for integrating with the Diamond Kinetics public API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './lib/dto';
 export * from './lib/enum';
 export * from './lib/types';
-export * from './lib/mock';


### PR DESCRIPTION
# What's Here

This fixes an export statement that is referencing mocks that no longer exist.
